### PR TITLE
카카오 소셜 로그인 이메일 오류 해결

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -28,10 +28,8 @@ const socialLogin = async (req: Request, res: Response, next: NextFunction) => {
     } else if (!data) {
       return res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.KAKAO_TOKEN_ERROR));
     }
-    const responseData = {
-      accessToken: data,
-    };
-    res.status(statusCode.OK).send(util.success(statusCode.OK, message.USER_LOGIN_SUCCESS, responseData));
+
+    res.status(statusCode.OK).send(util.success(statusCode.OK, message.USER_LOGIN_SUCCESS, data));
   } catch (error) {
     console.log(error);
     res.status(statusCode.INTERNAL_SERVER_ERROR).send;

--- a/src/interfaces/auth/response/LoginResponseDto.ts
+++ b/src/interfaces/auth/response/LoginResponseDto.ts
@@ -1,3 +1,5 @@
 export interface LoginResponseDto {
-    accessToken: string;
+  email: string;
+  nickname: string;
+  accessToken: string;
 }

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -26,14 +26,15 @@ const kakaoLogin = async (loginRequestDto: LoginRequestDto): Promise<LoginRespon
     }
 
     let existUser = await User.findOne({
-      email: kakaoUserData.email,
+      email: kakaoUserData.kakao_account.email,
     });
 
     // 유저가 db에 없는 경우 유저 회원 가입
     if (!existUser) {
       const user = new User({
         socialType: 'KAKAO',
-        email: kakaoUserData.email,
+        email: kakaoUserData.kakao_account.email,
+        nickname: kakaoUserData.kakao_account.profile.nickname,
       });
 
       await user.save();
@@ -42,7 +43,13 @@ const kakaoLogin = async (loginRequestDto: LoginRequestDto): Promise<LoginRespon
 
     await User.findByIdAndUpdate(existUser._id, existUser);
 
-    return getToken(existUser._id);
+    const loginResponseDto: LoginResponseDto = {
+      email: existUser.email,
+      nickname: existUser.nickname,
+      accessToken: getToken(existUser._id)
+    }
+
+    return loginResponseDto;
   } catch (error) {
     console.log('kakao token error');
     return null;


### PR DESCRIPTION
## 🚅 PR 한 줄 요약

<!-- PR을 한줄로 요약해주세요. -->
카카오 소셜 로그인 이메일 오류 해결했습니다.

## 💻 PR 세부 내용

<!-- 수정/추가한 내용을 적어주세요. -->
responseDto에 accessToken뿐만 아니라 이메일과 닉네임도 추가했습니다.
카카오 소셜 로그인 이메일과 닉네임 찾아오도록 설정했습니다.
